### PR TITLE
Refine minor improvements

### DIFF
--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -9,6 +9,9 @@ on:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -21,7 +21,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.repository_owner }}
+          username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: build_push_image

--- a/.github/workflows/interchaintest.yml
+++ b/.github/workflows/interchaintest.yml
@@ -9,9 +9,6 @@ on:
 jobs:
   build-and-push-image:
     runs-on: ubuntu-latest
-    permissions:
-      contents: read
-      packages: write
     steps:
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -21,7 +18,7 @@ jobs:
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
-          username: ${{ github.actor }}
+          username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build and push
         id: build_push_image

--- a/custom/bank/keeper/keeper.go
+++ b/custom/bank/keeper/keeper.go
@@ -41,7 +41,7 @@ func NewBaseKeeper(
 	authority string,
 ) Keeper {
 	keeper := Keeper{
-		BaseKeeper: bankkeeper.NewBaseKeeper(cdc, storeKey, ak, blockedAddrs, authority), // TODO: how to set authority?
+		BaseKeeper: bankkeeper.NewBaseKeeper(cdc, storeKey, ak, blockedAddrs, authority),
 		ak:         alliancekeeper.Keeper{},
 		sk:         stakingkeeper.Keeper{},
 		tfmk:       tfmk,

--- a/x/mint/keeper/msg_server.go
+++ b/x/mint/keeper/msg_server.go
@@ -70,10 +70,6 @@ func (ms msgServer) FundModuleAccount(goCtx context.Context, req *types.MsgFundM
 
 func (ms msgServer) AddAccountToFundModuleSet(goCtx context.Context, req *types.MsgAddAccountToFundModuleSet) (*types.MsgAddAccountToFundModuleSetResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
-	err := req.ValidateBasic()
-	if err != nil {
-		return nil, errorsmod.Wrapf(types.ErrValidationMsg, "invalid req msg %v - err %v", req, err)
-	}
 
 	if ms.authority != req.Authority {
 		return nil, errorsmod.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", ms.authority, req.Authority)

--- a/x/mint/types/msg.go
+++ b/x/mint/types/msg.go
@@ -68,14 +68,14 @@ func (m MsgAddAccountToFundModuleSet) GetSignBytes() []byte {
 
 // ValidateBasic does a sanity check on the provided data.
 func (m MsgAddAccountToFundModuleSet) ValidateBasic() error {
-	_, err := sdk.AccAddressFromBech32(m.AllowedAddress)
+	_, err := sdk.AccAddressFromBech32(m.Authority)
 	if err != nil {
-		return errorsmod.Wrap(err, "from address must be valid address")
+		return errorsmod.Wrap(err, "authority must be valid address")
 	}
 
 	_, err = sdk.AccAddressFromBech32(m.AllowedAddress)
 	if err != nil {
-		return errorsmod.Wrap(err, "from address must be valid address")
+		return errorsmod.Wrap(err, "allowed address must be valid address")
 	}
 
 	return nil

--- a/x/ratelimit/client/cli/tx.go
+++ b/x/ratelimit/client/cli/tx.go
@@ -11,7 +11,7 @@ import (
 // GetTxCmd returns the tx commands for router
 func GetTxCmd() *cobra.Command {
 	txCmd := &cobra.Command{
-		Use:                        "ratelimit",
+		Use:                        types.ModuleName,
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		Short:                      fmt.Sprintf("Tx commands for the %s module", types.ModuleName),

--- a/x/ratelimit/client/cli/tx.go
+++ b/x/ratelimit/client/cli/tx.go
@@ -11,7 +11,7 @@ import (
 // GetTxCmd returns the tx commands for router
 func GetTxCmd() *cobra.Command {
 	txCmd := &cobra.Command{
-		Use:                        "transfermiddleware",
+		Use:                        "ratelimit",
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		Short:                      fmt.Sprintf("Tx commands for the %s module", types.ModuleName),

--- a/x/transfermiddleware/client/cli/query.go
+++ b/x/transfermiddleware/client/cli/query.go
@@ -14,7 +14,7 @@ import (
 // GetQueryCmd returns the query commands for router
 func GetQueryCmd() *cobra.Command {
 	queryCmd := &cobra.Command{
-		Use:                        "transfermiddleware",
+		Use:                        types.ModuleName,
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 	}

--- a/x/transfermiddleware/client/cli/tx.go
+++ b/x/transfermiddleware/client/cli/tx.go
@@ -15,7 +15,7 @@ import (
 // GetTxCmd returns the tx commands for router
 func GetTxCmd() *cobra.Command {
 	txCmd := &cobra.Command{
-		Use:                        "transfermiddleware",
+		Use:                        types.ModuleName,
 		DisableFlagParsing:         true,
 		SuggestionsMinimumDistance: 2,
 		Short:                      "Registry and remove IBC dotsama chain information",


### PR DESCRIPTION
## Description

This PR refines minor improvements:

- Remove pending TODO comment of how to set authority. 
   - `NewBaseKeeper` it is set with governance module account in `app.go`)
- Remove duplicate validation in `AddAccountToFundModuleSet` as stateless check is already done during `CheckTx`.
- Fix `ValidateBasic` for `MsgAddAccountToFundModuleSet`. It was validating the same address twice.
- Use `types.ModuleName` throughout the modules instead of constant value. Notice that the `ratelimit` module was having `transfermiddleware` value in its `tx.go`.

Please, feel free to let me know if there are other minor improvements that can be made in this PR. I am happy to contribute.