### PR TITLE
Support additional CLI query commands for the `ratelimit` module

### DIFF
--- a/x/ratelimit/keeper/grpc_query.go
+++ b/x/ratelimit/keeper/grpc_query.go
@@ -11,17 +11,22 @@ import (
 	"github.com/notional-labs/centauri/v5/x/ratelimit/types"
 )
 
-var _ types.QueryServer = Keeper{}
+// Querier is used as Keeper will have duplicate methods if used directly, and gRPC names take precedence over keeper.
+type Querier struct {
+	Keeper
+}
 
-// Query all rate limits
-func (k Keeper) AllRateLimits(goCtx context.Context, _ *types.QueryAllRateLimitsRequest) (*types.QueryAllRateLimitsResponse, error) {
+var _ types.QueryServer = Querier{}
+
+// AllRateLimits queries all rate limits.
+func (k Querier) AllRateLimits(goCtx context.Context, _ *types.QueryAllRateLimitsRequest) (*types.QueryAllRateLimitsResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	rateLimits := k.GetAllRateLimits(ctx)
 	return &types.QueryAllRateLimitsResponse{RateLimits: rateLimits}, nil
 }
 
-// Query a rate limit by denom and channelID
-func (k Keeper) RateLimit(goCtx context.Context, req *types.QueryRateLimitRequest) (*types.QueryRateLimitResponse, error) {
+// RateLimit queries a rate limit by denom and channel id.
+func (k Querier) RateLimit(goCtx context.Context, req *types.QueryRateLimitRequest) (*types.QueryRateLimitResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	rateLimit, found := k.GetRateLimit(ctx, req.Denom, req.ChannelID)
 	if !found {
@@ -30,8 +35,8 @@ func (k Keeper) RateLimit(goCtx context.Context, req *types.QueryRateLimitReques
 	return &types.QueryRateLimitResponse{RateLimit: &rateLimit}, nil
 }
 
-// Query all rate limits for a given chain
-func (k Keeper) RateLimitsByChainID(goCtx context.Context, req *types.QueryRateLimitsByChainIDRequest) (*types.QueryRateLimitsByChainIDResponse, error) {
+// RateLimitsByChainID queries all rate limits for a given chain.
+func (k Querier) RateLimitsByChainID(goCtx context.Context, req *types.QueryRateLimitsByChainIDRequest) (*types.QueryRateLimitsByChainIDResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	rateLimits := []types.RateLimit{}
@@ -56,8 +61,8 @@ func (k Keeper) RateLimitsByChainID(goCtx context.Context, req *types.QueryRateL
 	return &types.QueryRateLimitsByChainIDResponse{RateLimits: rateLimits}, nil
 }
 
-// Query all rate limits for a given channel
-func (k Keeper) RateLimitsByChannelID(goCtx context.Context, req *types.QueryRateLimitsByChannelIDRequest) (*types.QueryRateLimitsByChannelIDResponse, error) {
+// RateLimitsByChannelID queries all rate limits for a given channel.
+func (k Querier) RateLimitsByChannelID(goCtx context.Context, req *types.QueryRateLimitsByChannelIDRequest) (*types.QueryRateLimitsByChannelIDResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
 	rateLimits := []types.RateLimit{}
@@ -71,8 +76,8 @@ func (k Keeper) RateLimitsByChannelID(goCtx context.Context, req *types.QueryRat
 	return &types.QueryRateLimitsByChannelIDResponse{RateLimits: rateLimits}, nil
 }
 
-// Query all whitelisted addresses
-func (k Keeper) AllWhitelistedAddresses(goCtx context.Context, _ *types.QueryAllWhitelistedAddressesRequest) (*types.QueryAllWhitelistedAddressesResponse, error) {
+// AllWhitelistedAddresses queries all whitelisted addresses.
+func (k Querier) AllWhitelistedAddresses(goCtx context.Context, _ *types.QueryAllWhitelistedAddressesRequest) (*types.QueryAllWhitelistedAddressesResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 	whitelistedAddresses := k.GetAllWhitelistedAddressPairs(ctx)
 	return &types.QueryAllWhitelistedAddressesResponse{AddressPairs: whitelistedAddresses}, nil

--- a/x/ratelimit/keeper/keeper_test.go
+++ b/x/ratelimit/keeper/keeper_test.go
@@ -1,0 +1,42 @@
+package keeper_test
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/suite"
+
+	tmproto "github.com/cometbft/cometbft/proto/tendermint/types"
+	sdk "github.com/cosmos/cosmos-sdk/types"
+
+	"github.com/notional-labs/centauri/v5/app"
+	"github.com/notional-labs/centauri/v5/app/helpers"
+	"github.com/notional-labs/centauri/v5/x/ratelimit/keeper"
+	"github.com/notional-labs/centauri/v5/x/ratelimit/types"
+)
+
+type KeeperTestSuite struct {
+	suite.Suite
+
+	app       *app.CentauriApp
+	ctx       sdk.Context
+	keeper    keeper.Keeper
+	querier   types.QueryServer
+	msgServer types.MsgServer
+}
+
+func TestKeeperTestSuite(t *testing.T) {
+	suite.Run(t, new(KeeperTestSuite))
+}
+
+func (s *KeeperTestSuite) SetupTest() {
+	s.app = helpers.SetupCentauriAppWithValSet(s.T())
+	s.ctx = s.app.BaseApp.NewContext(false, tmproto.Header{
+		Height:  1,
+		ChainID: "centauri-1",
+		Time:    time.Now().UTC(),
+	})
+	s.keeper = s.app.RatelimitKeeper
+	s.querier = keeper.NewQueryServer(s.keeper)
+	s.msgServer = keeper.NewMsgServerImpl(s.keeper)
+}

--- a/x/ratelimit/keeper/msg_server.go
+++ b/x/ratelimit/keeper/msg_server.go
@@ -10,7 +10,9 @@ import (
 	"github.com/notional-labs/centauri/v5/x/ratelimit/types"
 )
 
-var _ types.MsgServer = msgServer{}
+type msgServer struct {
+	Keeper
+}
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
@@ -20,60 +22,58 @@ func NewMsgServerImpl(keeper Keeper) types.MsgServer {
 	}
 }
 
-type msgServer struct {
-	Keeper
-}
+var _ types.MsgServer = msgServer{}
 
-func (k Keeper) AddTransferRateLimit(goCtx context.Context, msg *types.MsgAddRateLimit) (*types.MsgAddRateLimitResponse, error) {
+func (m msgServer) AddTransferRateLimit(goCtx context.Context, msg *types.MsgAddRateLimit) (*types.MsgAddRateLimitResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if k.authority != msg.Authority {
-		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.authority, msg.Authority)
+	if m.authority != msg.Authority {
+		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", m.authority, msg.Authority)
 	}
 
-	if err := k.AddRateLimit(ctx, msg); err != nil {
+	if err := m.AddRateLimit(ctx, msg); err != nil {
 		return nil, err
 	}
 
 	return &types.MsgAddRateLimitResponse{}, nil
 }
 
-func (k Keeper) UpdateTransferRateLimit(goCtx context.Context, msg *types.MsgUpdateRateLimit) (*types.MsgUpdateRateLimitResponse, error) {
+func (m msgServer) UpdateTransferRateLimit(goCtx context.Context, msg *types.MsgUpdateRateLimit) (*types.MsgUpdateRateLimitResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if k.authority != msg.Authority {
-		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.authority, msg.Authority)
+	if m.authority != msg.Authority {
+		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", m.authority, msg.Authority)
 	}
 
-	if err := k.UpdateRateLimit(ctx, msg); err != nil {
+	if err := m.UpdateRateLimit(ctx, msg); err != nil {
 		return nil, err
 	}
 
 	return &types.MsgUpdateRateLimitResponse{}, nil
 }
 
-func (k Keeper) RemoveTransferRateLimit(goCtx context.Context, msg *types.MsgRemoveRateLimit) (*types.MsgRemoveRateLimitResponse, error) {
+func (m msgServer) RemoveTransferRateLimit(goCtx context.Context, msg *types.MsgRemoveRateLimit) (*types.MsgRemoveRateLimitResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if k.authority != msg.Authority {
-		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.authority, msg.Authority)
+	if m.authority != msg.Authority {
+		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", m.authority, msg.Authority)
 	}
 
-	if err := k.RemoveRateLimit(ctx, msg.Denom, msg.ChannelID); err != nil {
+	if err := m.RemoveRateLimit(ctx, msg.Denom, msg.ChannelID); err != nil {
 		return nil, err
 	}
 
 	return &types.MsgRemoveRateLimitResponse{}, nil
 }
 
-func (k Keeper) ResetTransferRateLimit(goCtx context.Context, msg *types.MsgResetRateLimit) (*types.MsgResetRateLimitResponse, error) {
+func (m msgServer) ResetTransferRateLimit(goCtx context.Context, msg *types.MsgResetRateLimit) (*types.MsgResetRateLimitResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)
 
-	if k.authority != msg.Authority {
-		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.authority, msg.Authority)
+	if m.authority != msg.Authority {
+		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", m.authority, msg.Authority)
 	}
 
-	if err := k.ResetRateLimit(ctx, msg.Denom, msg.ChannelID); err != nil {
+	if err := m.ResetRateLimit(ctx, msg.Denom, msg.ChannelID); err != nil {
 		return nil, err
 	}
 

--- a/x/ratelimit/keeper/msg_server.go
+++ b/x/ratelimit/keeper/msg_server.go
@@ -10,19 +10,19 @@ import (
 	"github.com/notional-labs/centauri/v5/x/ratelimit/types"
 )
 
+var _ types.MsgServer = msgServer{}
+
 type msgServer struct {
 	Keeper
 }
 
 // NewMsgServerImpl returns an implementation of the MsgServer interface
 // for the provided Keeper.
-func NewMsgServerImpl(keeper Keeper) types.MsgServer {
+func NewMsgServerImpl(k Keeper) types.MsgServer {
 	return &msgServer{
-		Keeper: keeper,
+		Keeper: k,
 	}
 }
-
-var _ types.MsgServer = msgServer{}
 
 func (m msgServer) AddTransferRateLimit(goCtx context.Context, msg *types.MsgAddRateLimit) (*types.MsgAddRateLimitResponse, error) {
 	ctx := sdk.UnwrapSDKContext(goCtx)

--- a/x/ratelimit/keeper/msg_server.go
+++ b/x/ratelimit/keeper/msg_server.go
@@ -31,12 +31,7 @@ func (k Keeper) AddTransferRateLimit(goCtx context.Context, msg *types.MsgAddRat
 		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.authority, msg.Authority)
 	}
 
-	if err := msg.ValidateBasic(); err != nil {
-		return nil, err
-	}
-
-	err := k.AddRateLimit(ctx, msg)
-	if err != nil {
+	if err := k.AddRateLimit(ctx, msg); err != nil {
 		return nil, err
 	}
 
@@ -50,12 +45,7 @@ func (k Keeper) UpdateTransferRateLimit(goCtx context.Context, msg *types.MsgUpd
 		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.authority, msg.Authority)
 	}
 
-	if err := msg.ValidateBasic(); err != nil {
-		return nil, err
-	}
-
-	err := k.UpdateRateLimit(ctx, msg)
-	if err != nil {
+	if err := k.UpdateRateLimit(ctx, msg); err != nil {
 		return nil, err
 	}
 
@@ -69,8 +59,7 @@ func (k Keeper) RemoveTransferRateLimit(goCtx context.Context, msg *types.MsgRem
 		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.authority, msg.Authority)
 	}
 
-	err := k.RemoveRateLimit(ctx, msg.Denom, msg.ChannelID)
-	if err != nil {
+	if err := k.RemoveRateLimit(ctx, msg.Denom, msg.ChannelID); err != nil {
 		return nil, err
 	}
 
@@ -84,9 +73,9 @@ func (k Keeper) ResetTransferRateLimit(goCtx context.Context, msg *types.MsgRese
 		return nil, errors.Wrapf(govtypes.ErrInvalidSigner, "invalid authority; expected %s, got %s", k.authority, msg.Authority)
 	}
 
-	err := k.ResetRateLimit(ctx, msg.Denom, msg.ChannelID)
-	if err != nil {
+	if err := k.ResetRateLimit(ctx, msg.Denom, msg.ChannelID); err != nil {
 		return nil, err
 	}
+
 	return &types.MsgResetRateLimitResponse{}, nil
 }

--- a/x/ratelimit/module.go
+++ b/x/ratelimit/module.go
@@ -97,7 +97,7 @@ func (AppModule) QuerierRoute() string {
 
 // RegisterServices registers module services.
 func (am AppModule) RegisterServices(cfg module.Configurator) {
-	types.RegisterQueryServer(cfg.QueryServer(), am.keeper)
+	types.RegisterQueryServer(cfg.QueryServer(), keeper.NewQueryServer(*am.keeper))
 	types.RegisterMsgServer(cfg.MsgServer(), keeper.NewMsgServerImpl(*am.keeper))
 }
 

--- a/x/ratelimit/types/msg.go
+++ b/x/ratelimit/types/msg.go
@@ -8,14 +8,20 @@ import (
 	host "github.com/cosmos/ibc-go/v7/modules/core/24-host"
 )
 
+var (
+	_ sdk.Msg = &MsgAddRateLimit{}
+	_ sdk.Msg = &MsgUpdateRateLimit{}
+	_ sdk.Msg = &MsgRemoveRateLimit{}
+	_ sdk.Msg = &MsgResetRateLimit{}
+)
+
+// Message types for the module
 const (
 	TypeMsgAddRateLimit    = "add_rate_limit"
 	TypeMsgUpdateRateLimit = "update_rate_limit"
 	TypeMsgRemoveRateLimit = "remove_rate_limit"
 	TypeMsgResetRateLimit  = "reset_rate_limit"
 )
-
-var _ sdk.Msg = &MsgAddRateLimit{}
 
 func NewMsgAddRateLimit(
 	authority string,
@@ -54,12 +60,10 @@ func (msg *MsgAddRateLimit) GetSigners() []sdk.AccAddress {
 
 // ValidateBasic does a sanity check on the provided data.
 func (msg *MsgAddRateLimit) ValidateBasic() error {
-	// validate authority
 	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
 		return errorsmod.Wrap(err, "invalid authority address")
 	}
 
-	// validate channelIDs
 	if err := host.ChannelIdentifierValidator(msg.ChannelID); err != nil {
 		return err
 	}
@@ -86,8 +90,6 @@ func (msg *MsgAddRateLimit) ValidateBasic() error {
 
 	return nil
 }
-
-var _ sdk.Msg = &MsgUpdateRateLimit{}
 
 func NewMsgUpdateRateLimit(
 	authority string,
@@ -126,12 +128,10 @@ func (msg *MsgUpdateRateLimit) GetSigners() []sdk.AccAddress {
 
 // ValidateBasic does a sanity check on the provided data.
 func (msg *MsgUpdateRateLimit) ValidateBasic() error {
-	// validate authority
 	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
 		return errorsmod.Wrap(err, "invalid authority address")
 	}
 
-	// validate channelIDs
 	if err := host.ChannelIdentifierValidator(msg.ChannelID); err != nil {
 		return err
 	}
@@ -158,8 +158,6 @@ func (msg *MsgUpdateRateLimit) ValidateBasic() error {
 
 	return nil
 }
-
-var _ sdk.Msg = &MsgRemoveRateLimit{}
 
 func NewMsgRemoveRateLimit(
 	authority string,
@@ -192,18 +190,16 @@ func (msg *MsgRemoveRateLimit) GetSigners() []sdk.AccAddress {
 
 // ValidateBasic does a sanity check on the provided data.
 func (msg *MsgRemoveRateLimit) ValidateBasic() error {
-	// validate authority
 	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
 		return errorsmod.Wrap(err, "invalid authority address")
 	}
 
-	// validate channelIDs
-	err := host.ChannelIdentifierValidator(msg.ChannelID)
+	if err := host.ChannelIdentifierValidator(msg.ChannelID); err != nil {
+		return err
+	}
 
-	return err
+	return nil
 }
-
-var _ sdk.Msg = &MsgResetRateLimit{}
 
 func NewMsgResetRateLimit(
 	authority string,
@@ -236,13 +232,13 @@ func (msg *MsgResetRateLimit) GetSigners() []sdk.AccAddress {
 
 // ValidateBasic does a sanity check on the provided data.
 func (msg *MsgResetRateLimit) ValidateBasic() error {
-	// validate authority
 	if _, err := sdk.AccAddressFromBech32(msg.Authority); err != nil {
 		return errorsmod.Wrap(err, "invalid authority address")
 	}
 
-	// validate channelIDs
-	err := host.ChannelIdentifierValidator(msg.ChannelID)
+	if err := host.ChannelIdentifierValidator(msg.ChannelID); err != nil {
+		return err
+	}
 
-	return err
+	return nil
 }


### PR DESCRIPTION
## Description

This PR resolves #240 

## Tasks
- [x] Remove redundant message validation in msgServer level
- [x] Organize `types/msgs.go`
- [x] Define `msgServer` and `queryServer` to enhance clarify
- [ ] Add CLI query commands for unsupported gRPC query services
- [ ] Add test cases for gRPC query services